### PR TITLE
Add ability to inject the view content via middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
-        "orchestra/testbench": "3.1"
+        "orchestra/testbench": "3.1",
+        "fzaninotto/faker": "~1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/CookieConsentMiddleware.php
+++ b/src/CookieConsentMiddleware.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\CookieConsent;
+
+use Closure;
+use Illuminate\Http\Response;
+use Illuminate\Contracts\Foundation\Application;
+
+class CookieConsentMiddleware
+{
+    /**
+     * The application implementation.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application $app
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        if ($response instanceof Response) {
+            $content = $response->getContent();
+
+            $cookieConsentHTML = view('cookieConsent::index')->render();
+
+            if (($bodyPosition = strripos($content, '</body>')) !== false) {
+                $content = ''
+                    .substr($content, 0, $bodyPosition)
+                    .$cookieConsentHTML
+                    .substr($content, $bodyPosition);
+            }
+
+            $response->setContent($content);
+        }
+
+        return $response;
+    }
+}

--- a/tests/CookieConsentTest.php
+++ b/tests/CookieConsentTest.php
@@ -2,6 +2,10 @@
 
 namespace Spatie\CookieConsent\Test;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\CookieConsent\CookieConsentMiddleware;
+
 class CookieConsentTest extends TestCase
 {
     /** @test */
@@ -39,5 +43,19 @@ class CookieConsentTest extends TestCase
         $html = view('layout')->render();
 
         $this->assertConsentDialogIsNotDisplayed($html);
+    }
+
+    /** @test */
+    public function it_injects_the_view_via_middleware()
+    {
+        $request = new Request();
+
+        $middleware = new CookieConsentMiddleware($this->app);
+
+        $result = $middleware->handle($request, function ($request) {
+            return (new Response())->setContent('<html><head></head><body></body></html>');
+        });
+
+        $this->assertContains('window.laravelCookieConsent', $result->getContent());
     }
 }


### PR DESCRIPTION
By adding `CookieConsentMiddleware::class` to the web middleware, the view will be injected by default before the closing body tag `</body>`.

I also added a missing dependency which was causing the build to fail earlier.