### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
-        "illuminate/view": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
-        "illuminate/cookie": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev"
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/view": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/cookie": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "~3.1.0|~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev",
-        "orchestra/database": "~3.1.0|~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev",
+        "orchestra/testbench": "~3.1.0|~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev|~3.5.x-dev",
+        "orchestra/database": "~3.1.0|~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev|~3.5.x-dev",
         "fzaninotto/faker": "~1.4"
     },
     "autoload": {
@@ -58,3 +58,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,15 @@
         }
     ],
     "require": {
-        "php" : "^5.6|^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/view": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/cookie": "~5.1.0|~5.2.0|~5.3.0|~5.4.0"
+        "php": "^5.6|^7.0",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/view": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/cookie": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*",
-        "orchestra/testbench": "~3.1.0|~3.2.0|~3.3.0|~3.4.0@dev",
-        "orchestra/database": "~3.1.0|~3.2.0|~3.3.0|~3.4.0@dev",
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "~3.1.0|~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev",
+        "orchestra/database": "~3.1.0|~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev",
         "fzaninotto/faker": "~1.4"
     },
     "autoload": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-cookie-consent/phpunit.xml.dist

......                                                              6 / 6 (100%)

Time: 945 ms, Memory: 12.00MB

OK (6 tests, 9 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments