### PR TITLE
Fix spelling of test name from sucre to secure

### DIFF
--- a/tests/CookieConsentMiddlewareTest.php
+++ b/tests/CookieConsentMiddlewareTest.php
@@ -43,7 +43,7 @@ class CookieConsentMiddlewareTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_use_a_sucre_cookie_if_session_secure_is_false()
+    public function it_does_not_use_a_secure_cookie_if_session_secure_is_false()
     {
         config(['session.secure' => false]);
 


### PR DESCRIPTION
I (heart) sucre cookies, but I suppose we're not testing for that here ;)

`it_does_not_use_a_sucre_cookie_if_session_secure_is_false`