### PR TITLE
Fix tests to properly and completely check what they say they do

### DIFF
--- a/tests/CookieConsentMiddlewareTest.php
+++ b/tests/CookieConsentMiddlewareTest.php
@@ -54,6 +54,7 @@ class CookieConsentMiddlewareTest extends TestCase
         });
 
         $this->assertContains('document.cookie = name + \'=\' + value + \'; \' + \'expires=\' + date.toUTCString() +\';path=/\';', $result->getContent());
+        $this->assertNotContains('document.cookie = name + \'=\' + value + \'; \' + \'expires=\' + date.toUTCString() +\';path=/;secure\';', $result->getContent());
     }
 
     /** @test */

--- a/tests/CookieConsentTest.php
+++ b/tests/CookieConsentTest.php
@@ -32,9 +32,7 @@ class CookieConsentTest extends TestCase
     /** @test */
     public function it_will_not_show_the_cookie_consent_view_when_the_user_has_already_consented()
     {
-        $this->app['config']->set('cookie-consent.enabled', false);
-
-        cookie(config('cookie-consent.cookie_name'), 1);
+        request()->cookies->set(config('cookie-consent.cookie_name'), cookie(config('cookie-consent.cookie_name'), 1));
 
         $html = view('layout')->render();
 


### PR DESCRIPTION
- `CookieConsentMiddlewareTest::it_does_not_use_a_secure_cookie_if_session_secure_is_false()` now confirms that the secure cookie is _not_ set, in addition to ensuring the insecure cookie is
- `CookieConsentTest::it_will_not_show_the_cookie_consent_view_when_the_user_has_already_consented()` now properly adds the cookie to the request (before it was simply creating the cookie, without actually doing anything with it), and does not disable the package altogether

Fixes #75.