### PR TITLE
Add middleware to remove all unapproved cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,31 @@ class Kernel extends HttpKernel
 
 This will automatically add `cookieConsent::index` to the content of your response right before the closing body tag.
 
-## Notice
-The legislation is pretty very vague on how to display the warning, which texts are necessary, and what options you need to provide. This package will go a long way towards compliance, but if you want to be 100% sure that your website is ok, you should consult a legal expert.
+## Optional: remove all cookies without consent
 
+If you want to force your app to not set any cookies at all – even the ones used by sessions and CSRF protections – this is easy to do. Just add the `Spatie\CookieConsent\RemoveCookiesWithoutConsentMiddleware` to your kernel, at the very top of the list:
+
+```php
+// app/Http/Kernel.php
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        \Spatie\CookieConsent\RemoveCookiesWithoutConsentMiddleware::class,
+        // ...
+    ];
+
+    // ...
+}
+```
+
+This will simply remove all cookies from the response, without any further interaction from you, so long as `enabled` is `true` in your config, and the user hasn't (yet) consented to cookies being set.
+
+> Note: This does have some potential drawbacks you should take into account. Specifically, sessions will not work without being able to set a cookie on the response, to track which session is which. This in turn means forms will also fail to submit, as there is no way to look up the correct CSRF token without a session to store it in. You can work around this by adding a `window.location.reload()` to the `consentWithCookies()` function in the `index` view file, to get a session cookie you can use. Alternately, if you want session cookies to still be set, you can place this middleware after `Illuminate\Session\Middleware\StartSession`, so that the session cookies are added to the request after `RemoveCookiesWithoutConsentMiddleware` has already returned.
+
+## Notice
+
+The legislation is pretty very vague on how to display the warning, which texts are necessary, and what options you need to provide. This package will go a long way towards compliance, but if you want to be 100% sure that your website is ok, you should consult a legal expert.
 
 ## Changelog
 

--- a/src/RemoveCookiesWithoutConsentMiddleware.php
+++ b/src/RemoveCookiesWithoutConsentMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\CookieConsent;
+
+use Closure;
+
+class RemoveCookiesWithoutConsentMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        if (config('cookie-consent.enabled') && ! $request->cookies->has(config('cookie-consent.cookie_name'))) {
+            $response->headers->remove('set-cookie');
+        }
+
+        return $response;
+    }
+}

--- a/tests/RemoveCookiesWithoutConsentMiddlewareTest.php
+++ b/tests/RemoveCookiesWithoutConsentMiddlewareTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\CookieConsent\Test;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\CookieConsent\RemoveCookiesWithoutConsentMiddleware;
+
+class RemoveCookiesWithoutConsentMiddlewareTest extends TestCase
+{
+    /** @test */
+    public function it_removes_cookies_when_consent_is_not_given()
+    {
+        $request = new Request();
+        $rawResponse = (new Response())->withCookie('test-cookie', 42);
+
+        $this->assertNotEmpty($rawResponse->headers->getCookies(), 'Raw response doesn\'t include any cookies!');
+
+        $middleware = new RemoveCookiesWithoutConsentMiddleware($this->app);
+        $response = $middleware->handle($request, function ($request) use ($rawResponse) {
+            return $rawResponse;
+        });
+
+        $this->assertEmpty($response->headers->getCookies(), 'Cookies should be, but aren\'t, removed when consent isn\'t given!');
+    }
+
+    /** @test */
+    public function it_does_not_remove_cookies_when_consent_is_given()
+    {
+        $request = new Request();
+        $request->cookies->set(config('cookie-consent.cookie_name'), cookie(config('cookie-consent.cookie_name'), 1));
+
+        $rawResponse = (new Response())->withCookie('test-cookie', 42);
+        $this->assertNotEmpty($rawResponse->headers->getCookies(), 'Raw response doesn\'t include any cookies!');
+
+        $middleware = new RemoveCookiesWithoutConsentMiddleware($this->app);
+        $response = $middleware->handle($request, function ($request) use ($rawResponse) {
+            return $rawResponse;
+        });
+
+        $this->assertNotEmpty($response->headers->getCookies(), 'Cookies shouldn\'t be, but are, removed despite the fact consent is given!');
+    }
+}


### PR DESCRIPTION
For users who wish to ensure there are no cookies set by their apps unless/until the user agrees to them, this new middleware, which should be added to the top of the web middlewares, will remove all cookies from the response. it is entirely optional, and there is a small impact on site usability when it is in use (session cookies aren't sent, so things like CSRF don't work), but informed users will have the option in any case, and the limitations can be worked around, as noted in the README.