### PR TITLE
Use session.same_site to set the Cookie's SameSite Attribute

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -32,7 +32,8 @@
                 document.cookie = name + '=' + value
                     + ';expires=' + date.toUTCString()
                     + ';domain=' + COOKIE_DOMAIN
-                    + ';path=/{{ config('session.secure') ? ';secure' : null }}';
+                    + ';path=/{{ config('session.secure') ? ';secure' : null }}'
+                    + '{{ config('session.same_site') ? ';samesite='.config('session.same_site') : null }}';
             }
 
             if (cookieExists('{{ $cookieConsentConfig['cookie_name'] }}')) {

--- a/tests/CookieConsentMiddlewareTest.php
+++ b/tests/CookieConsentMiddlewareTest.php
@@ -53,8 +53,8 @@ class CookieConsentMiddlewareTest extends TestCase
             return (new Response())->setContent('<html><head></head><body></body></html>');
         });
 
-        $this->assertStringContainsString(';path=/\';', $result->getContent());
-        $this->assertStringNotContainsString(';path=/;secure\';', $result->getContent());
+        $this->assertStringContainsString(';path=/\'', $result->getContent());
+        $this->assertStringNotContainsString(';path=/;secure\'', $result->getContent());
     }
 
     /** @test */
@@ -68,8 +68,8 @@ class CookieConsentMiddlewareTest extends TestCase
             return (new Response())->setContent('<html><head></head><body></body></html>');
         });
 
-        $this->assertStringNotContainsString(';path=/\';', $result->getContent());
-        $this->assertStringContainsString(';path=/;secure\';', $result->getContent());
+        $this->assertStringNotContainsString(';path=/\'', $result->getContent());
+        $this->assertStringContainsString(';path=/;secure\'', $result->getContent());
     }
 
     /** @test */
@@ -84,6 +84,34 @@ class CookieConsentMiddlewareTest extends TestCase
         });
 
         $this->assertStringContainsString('const COOKIE_DOMAIN = \'some domain\'', $result->getContent());
+    }
+
+    /** @test */
+    public function the_cookie_samesite_attribute_is_not_set_if_config_session_is_set_to_false()
+    {
+        config(['session.same_site' => null]);
+
+        $middleware = new CookieConsentMiddleware();
+
+        $result = $middleware->handle(new Request(), function () {
+            return (new Response())->setContent('<html><head></head><body></body></html>');
+        });
+
+        $this->assertStringNotContainsString(';samesite=', $result->getContent());
+    }
+
+    /** @test */
+    public function the_cookie_samesite_attribute_is_by_the_session_samesite_config_variable()
+    {
+        config(['session.same_site' => 'strict']);
+
+        $middleware = new CookieConsentMiddleware();
+
+        $result = $middleware->handle(new Request(), function () {
+            return (new Response())->setContent('<html><head></head><body></body></html>');
+        });
+
+        $this->assertStringContainsString(';samesite=strict', $result->getContent());
     }
 
     /** @test */


### PR DESCRIPTION
As more and more browsers start enforcing `SameSite` and `Secure` flags of a cookie, the [default Laravel config](https://github.com/laravel/laravel/blob/master/config/session.php#L171) prevents this package from setting the `Secure` flag of a cookie and some browsers, such as Firefox 78, will output a message like this one after the cookie has been set:

> Cookie “laravel_cookie_consent” will be soon rejected because it has the “sameSite” attribute set to “none” or an invalid value, without the “secure” attribute. To know more about the “sameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite

Which will eventually lead to this package not working correctly unless `session.secure` has been set correctly. However, an easy fix is possible: `session.same_site` defines the `SameSite` policy, which [defaults to `lax`](https://github.com/laravel/laravel/blob/master/config/session.php#L199).

By inheriting these values for this package's cookie, it will not only be future-proof (for now) but also consistent behavior with other Laravel cookies is ensured.

This PR adds the functionality described above and does not introduce any new config keys.

Please let me know if you'd like me to make any changes. And a big thank you for all the many fantastic packages you've made available!