### PR TITLE
Add support for excluded URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ return [
     'enabled' => env('COOKIE_CONSENT_ENABLED', true),
 
     /*
+     * Any URLs that should not display the cookie consent banner.
+     * Wildcards can be used
+     * 
+     * For example: ['admin/*']
+     */
+    'except' => [],
+
+    /*
      * The name of the cookie in which we store if the user
      * has agreed to accept the conditions.
      */
@@ -101,9 +109,21 @@ If you need full control over the contents of the dialog. You can publish the vi
 
 ```bash
 php artisan vendor:publish --provider="Spatie\CookieConsent\CookieConsentServiceProvider" --tag="views"
-```
+``` 
 
 This will copy the `index` and `dialogContents` view files over to `resources/views/vendor/cookieConsent`. You probably only want to modify the `dialogContents` view. If you need to modify the JavaScript code of this package you can do so in the `index` view file.
+
+### Preventing some routes from displaying the dialog
+
+If there are some routes you don't need the dialog displaying on you can use the `except` key in the config file.
+
+Any paths placed in this array will be excluded when displaying the dialog.
+
+```php
+'except' => [
+    'admin/*',
+],
+```
 
 ## Using the middleware
 

--- a/config/cookie-consent.php
+++ b/config/cookie-consent.php
@@ -8,6 +8,14 @@ return [
     'enabled' => env('COOKIE_CONSENT_ENABLED', true),
 
     /*
+     * Any URLs that should not display the cookie consent banner.
+     * Wildcards can be used
+     *
+     * For example: ['admin/*']
+     */
+    'except' => [],
+
+    /*
      * The name of the cookie in which we store if the user
      * has agreed to accept the conditions.
      */


### PR DESCRIPTION
This PR will add the ability to exclude some paths from having the Cookie Consent dialog from being automatically added to the response, including support for wildcard paths.

### Changes

I've added a new key to the config file, `except`, which defaults to an empty array, any paths placed in this array will be excluded from having the dialog applied.

The `CookieConsentMiddleware` class has been updated to check the request path against the entries in this array, if the path is in that array then the Middleware will just return the `$response` as it is.

I have also updated the readme to show the new `except` key in the default config file, and how it can be used.

I have added two tests to the `CookieConsentMiddlewareTest` class, one to test that the cookie consent dialog is not shown when visit a standard path without a wildcard, and an assertion just to make sure that it still does show on other routes.

The second test is for a wildcard route, where it asserts that the main top level of the wildcard, a level down, and a second level below that, don't get the dialog applied.

### Reason for Change

This is a great package but I noticed that in some of my routes (only standalone admin routes) that the cookie consent dialog was getting applied, but its just placed on the page with no styling since the CSS file with the styles for the consent aren't loaded on any non public facing pages, I looked for a way to prevent the dialog box from displaying on certain routes and was surprised that there wasn't already a way to do this!