### PR TITLE
Add PHP 8-only Support (v3)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,16 +10,14 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3]
-                laravel: [8.*, 7.*, 6.*]
+                php: [8.0]
+                laravel: [8.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     - laravel: 8.*
                       testbench: 6.*
                     - laravel: 7.*
                       testbench: 5.*
-                    - laravel: 6.*
-                      testbench: 4.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `cookie-consent` will be documented in this file
 
+## 3.0.0 - unreleased
+
+- require PHP 8.0+
+- drop support for PHP 7.x
+- convert syntax to PHP 8 where appropriate
+- implement spatie/laravel-package-tools
+
 ## 2.12.13 - 2021-02-26
 
 - add Vietnamese

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,15 @@
         }
     ],
     "require": {
-        "php" : "^7.3|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "illuminate/view": "^6.0|^7.0|^8.0",
-        "illuminate/cookie": "^6.0|^7.0|^8.0"
+        "php" : "^8.0",
+        "illuminate/support": "^7.0|^8.0",
+        "illuminate/view": "^7.0|^8.0",
+        "illuminate/cookie": "^7.0|^8.0",
+        "spatie/laravel-package-tools": "^1.6"
     },
     "require-dev": {
         "fakerphp/faker": "~1.9",
-        "orchestra/testbench": "^4.0|^5.0|^6.0"
+        "orchestra/testbench": "^5.0|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/resources/views/dialogContents.blade.php
+++ b/resources/views/dialogContents.blade.php
@@ -1,11 +1,11 @@
 <div class="js-cookie-consent cookie-consent">
 
     <span class="cookie-consent__message">
-        {!! trans('cookieConsent::texts.message') !!}
+        {!! trans('cookie-consent::texts.message') !!}
     </span>
 
     <button class="js-cookie-consent-agree cookie-consent__agree">
-        {{ trans('cookieConsent::texts.agree') }}
+        {{ trans('cookie-consent::texts.agree') }}
     </button>
 
 </div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,6 +1,6 @@
 @if($cookieConsentConfig['enabled'] && ! $alreadyConsentedWithCookies)
 
-    @include('cookieConsent::dialogContents')
+    @include('cookie-consent::dialogContents')
 
     <script>
 

--- a/src/CookieConsentMiddleware.php
+++ b/src/CookieConsentMiddleware.php
@@ -31,12 +31,7 @@ class CookieConsentMiddleware
         return $this->getLastClosingBodyTagPosition($response->getContent()) !== false;
     }
 
-    /**
-     * @param \Illuminate\Http\Response $response
-     *
-     * @return $this
-     */
-    protected function addCookieConsentScriptToResponse(Response $response)
+    protected function addCookieConsentScriptToResponse(Response $response): Response
     {
         $content = $response->getContent();
 
@@ -44,13 +39,13 @@ class CookieConsentMiddleware
 
         $content = ''
             .substr($content, 0, $closingBodyTagPosition)
-            .view('cookieConsent::index')->render()
+            .view('cookie-consent::index')->render()
             .substr($content, $closingBodyTagPosition);
 
         return $response->setContent($content);
     }
 
-    protected function getLastClosingBodyTagPosition(string $content = '')
+    protected function getLastClosingBodyTagPosition(string $content = ''): bool|int
     {
         return strripos($content, '</body>');
     }

--- a/tests/CookieConsentTest.php
+++ b/tests/CookieConsentTest.php
@@ -7,8 +7,8 @@ class CookieConsentTest extends TestCase
     /** @test */
     public function it_provides_translations()
     {
-        $this->assertTranslationExists('cookieConsent::texts.message');
-        $this->assertTranslationExists('cookieConsent::texts.agree');
+        $this->assertTranslationExists('cookie-consent::texts.message');
+        $this->assertTranslationExists('cookie-consent::texts.agree');
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,8 +43,8 @@ abstract class TestCase extends OrchestraTestCase
     protected function isConsentDialogDisplayed(string $html): bool
     {
         return \Illuminate\Support\Str::contains($html, [
-            trans('cookieConsent::texts.message'),
-            trans('cookieConsent::texts.button_text'),
+            trans('cookie-consent::texts.message'),
+            trans('cookie-consent::texts.button_text'),
         ]);
     }
 }

--- a/tests/stubs/views/layout.blade.php
+++ b/tests/stubs/views/layout.blade.php
@@ -1,1 +1,1 @@
-@include('cookieConsent::index')
+@include('cookie-consent::index')


### PR DESCRIPTION
This PR adds a new major version, v3.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- All syntax converted to PHP 8 where possible.
- Removes unnecessary PHP docblocks per Spatie's guidelines.
- Removes support for Laravel 6.x.
- Implements spatie/laravel-package-tools.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._