### PR TITLE
Replace trans helper

### DIFF
--- a/resources/views/dialogContents.blade.php
+++ b/resources/views/dialogContents.blade.php
@@ -4,12 +4,12 @@
             <div class="flex items-center justify-between flex-wrap">
                 <div class="w-0 flex-1 items-center hidden md:inline">
                     <p class="ml-3 text-yellow-600 cookie-consent__message">
-                        {!! trans('cookie-consent::texts.message') !!}
+                        {!! __('cookie-consent::texts.message') !!}
                     </p>
                 </div>
                 <div class="mt-2 flex-shrink-0 w-full sm:mt-0 sm:w-auto">
                     <a class="js-cookie-consent-agree cookie-consent__agree cursor-pointer flex items-center justify-center px-4 py-2 rounded-md text-sm font-medium text-yellow-800 bg-yellow-400 hover:bg-yellow-300">
-                        {{ trans('cookie-consent::texts.agree') }}
+                        {{ __('cookie-consent::texts.agree') }}
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Replaced the trans helper function to use the recommended __() helper, as described in the docs:

https://laravel.com/docs/master/localization#retrieving-translation-strings