### PR TITLE
Add contrast on text, anchor -> button

### DIFF
--- a/resources/views/dialogContents.blade.php
+++ b/resources/views/dialogContents.blade.php
@@ -3,14 +3,14 @@
         <div class="p-2 rounded-lg bg-yellow-100">
             <div class="flex items-center justify-between flex-wrap">
                 <div class="w-0 flex-1 items-center hidden md:inline">
-                    <p class="ml-3 text-yellow-600 cookie-consent__message">
+                    <p class="ml-3 text-black cookie-consent__message">
                         {!! trans('cookie-consent::texts.message') !!}
                     </p>
                 </div>
                 <div class="mt-2 flex-shrink-0 w-full sm:mt-0 sm:w-auto">
-                    <a class="js-cookie-consent-agree cookie-consent__agree cursor-pointer flex items-center justify-center px-4 py-2 rounded-md text-sm font-medium text-yellow-800 bg-yellow-400 hover:bg-yellow-300">
+                    <button class="js-cookie-consent-agree cookie-consent__agree cursor-pointer flex items-center justify-center px-4 py-2 rounded-md text-sm font-medium text-yellow-800 bg-yellow-400 hover:bg-yellow-300">
                         {{ trans('cookie-consent::texts.agree') }}
-                    </a>
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This is to improve the google lighthouse score by default.

Text color was reported as not enough contrast by default which is an accessibility issue.
Button is more appropriate than link and it reports it as non crawl-able.