### PR TITLE
fix - styling on smaller screens

### DIFF
--- a/resources/views/dialogContents.blade.php
+++ b/resources/views/dialogContents.blade.php
@@ -1,9 +1,9 @@
-<div class="js-cookie-consent cookie-consent fixed bottom-0 inset-x-0 pb-2">
+<div class="js-cookie-consent cookie-consent fixed bottom-0 inset-x-0 pb-2 z-50">
     <div class="max-w-7xl mx-auto px-6">
-        <div class="p-2 rounded-lg bg-yellow-100">
+        <div class="p-4 md:p-2 rounded-lg bg-yellow-100">
             <div class="flex items-center justify-between flex-wrap">
-                <div class="w-0 flex-1 items-center hidden md:inline">
-                    <p class="ml-3 text-black cookie-consent__message">
+                <div class="max-w-full flex-1 items-center md:w-0 md:inline">
+                    <p class="md:ml-3 text-black cookie-consent__message">
                         {!! trans('cookie-consent::texts.message') !!}
                     </p>
                 </div>


### PR DESCRIPTION
fix - styling on smaller screens (mobile) text was hidden entirely on phones

Previously it looked like this
![Screenshot 2024-07-12 at 16 15 41](https://github.com/user-attachments/assets/7e098a08-af3b-4b53-ad13-4b60b5f28bf1)
new look
![Screenshot 2024-07-12 at 16 02 04](https://github.com/user-attachments/assets/96a892f9-608d-48fb-8e8f-f572efadd59b)
